### PR TITLE
Implement minimal ASP.NET backend and Angular frontend

### DIFF
--- a/Backend/AliasEndpointExtensions.cs
+++ b/Backend/AliasEndpointExtensions.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Http;
 
 namespace UrlAlias;
 
-public static class AliasEndpoints
+public static class AliasEndpointExtensions
 {
     public static void MapAliasEndpoints(this WebApplication app)
     {

--- a/Backend/AliasEndpoints.cs
+++ b/Backend/AliasEndpoints.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace UrlAlias;
+
+public static class AliasEndpoints
+{
+    public static void MapAliasEndpoints(this WebApplication app)
+    {
+        app.MapGet("/api/aliases", (AliasService svc) => svc.GetAll());
+
+        app.MapGet("/api/aliases/{alias}", (string alias, AliasService svc) =>
+        {
+            var url = svc.TryGet(alias);
+            return url is not null ? Results.Ok(url) : Results.NotFound();
+        });
+
+        app.MapPost("/api/aliases", (AliasEntry input, AliasService svc) =>
+        {
+            var result = svc.Add(input);
+            return result == AddResult.Added
+                ? Results.Created($"/api/aliases/{input.Alias}", input)
+                : Results.Conflict(new { message = "Alias already exists" });
+        });
+    }
+}

--- a/Backend/AliasService.cs
+++ b/Backend/AliasService.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+
+namespace UrlAlias;
+
+public record AliasEntry(string Alias, string Url);
+public enum AddResult { Added, Exists }
+
+public class AliasService
+{
+    private readonly string _dataFile;
+    private readonly object _lock = new();
+    public AliasService(string dataFile)
+    {
+        _dataFile = dataFile;
+    }
+
+    public IDictionary<string, string> GetAll()
+    {
+        lock (_lock)
+        {
+            return Load();
+        }
+    }
+
+    public string? TryGet(string alias)
+    {
+        lock (_lock)
+        {
+            var aliases = Load();
+            return aliases.TryGetValue(alias, out var url) ? url : null;
+        }
+    }
+
+    public AddResult Add(AliasEntry entry)
+    {
+        lock (_lock)
+        {
+            var aliases = Load();
+            if (aliases.ContainsKey(entry.Alias))
+                return AddResult.Exists;
+            aliases[entry.Alias] = entry.Url;
+            Save(aliases);
+            return AddResult.Added;
+        }
+    }
+
+    private Dictionary<string, string> Load()
+    {
+        if (File.Exists(_dataFile))
+        {
+            try
+            {
+                var json = File.ReadAllText(_dataFile);
+                return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new();
+            }
+            catch
+            {
+                return new Dictionary<string, string>();
+            }
+        }
+        return new Dictionary<string, string>();
+    }
+
+    private void Save(Dictionary<string, string> aliases)
+    {
+        var json = JsonSerializer.Serialize(aliases, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(_dataFile, json);
+    }
+}

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+const string DataFile = "aliases.json";
+
+static IDictionary<string, string> LoadAliases()
+{
+    if (File.Exists(DataFile))
+    {
+        try
+        {
+            var json = File.ReadAllText(DataFile);
+            return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new();
+        }
+        catch
+        {
+            return new Dictionary<string, string>();
+        }
+    }
+    return new Dictionary<string, string>();
+}
+
+static void SaveAliases(IDictionary<string, string> aliases)
+{
+    var json = JsonSerializer.Serialize(aliases, new JsonSerializerOptions { WriteIndented = true });
+    File.WriteAllText(DataFile, json);
+}
+
+app.MapGet("/api/aliases", () => LoadAliases());
+
+app.MapGet("/api/aliases/{alias}", (string alias) =>
+{
+    var aliases = LoadAliases();
+    return aliases.TryGetValue(alias, out var url) ? Results.Ok(url) : Results.NotFound();
+});
+
+app.MapPost("/api/aliases", (AliasInput input) =>
+{
+    var aliases = LoadAliases();
+    if (aliases.ContainsKey(input.Alias))
+    {
+        return Results.Conflict(new { message = "Alias already exists" });
+    }
+    aliases[input.Alias] = input.Url;
+    SaveAliases(aliases);
+    return Results.Created($"/api/aliases/{input.Alias}", input);
+});
+
+app.Run();
+
+record AliasInput(string Alias, string Url);

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -1,53 +1,11 @@
-using System.Text.Json;
+using UrlAlias;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton(new AliasService("aliases.json"));
+
 var app = builder.Build();
 
-const string DataFile = "aliases.json";
-
-static IDictionary<string, string> LoadAliases()
-{
-    if (File.Exists(DataFile))
-    {
-        try
-        {
-            var json = File.ReadAllText(DataFile);
-            return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new();
-        }
-        catch
-        {
-            return new Dictionary<string, string>();
-        }
-    }
-    return new Dictionary<string, string>();
-}
-
-static void SaveAliases(IDictionary<string, string> aliases)
-{
-    var json = JsonSerializer.Serialize(aliases, new JsonSerializerOptions { WriteIndented = true });
-    File.WriteAllText(DataFile, json);
-}
-
-app.MapGet("/api/aliases", () => LoadAliases());
-
-app.MapGet("/api/aliases/{alias}", (string alias) =>
-{
-    var aliases = LoadAliases();
-    return aliases.TryGetValue(alias, out var url) ? Results.Ok(url) : Results.NotFound();
-});
-
-app.MapPost("/api/aliases", (AliasInput input) =>
-{
-    var aliases = LoadAliases();
-    if (aliases.ContainsKey(input.Alias))
-    {
-        return Results.Conflict(new { message = "Alias already exists" });
-    }
-    aliases[input.Alias] = input.Url;
-    SaveAliases(aliases);
-    return Results.Created($"/api/aliases/{input.Alias}", input);
-});
+app.MapAliasEndpoints();
 
 app.Run();
-
-record AliasInput(string Alias, string Url);

--- a/Backend/UrlAlias.csproj
+++ b/Backend/UrlAlias.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project provides a minimal ASP.NET Core backend with an Angular frontend to
 
 ## Backend
 
-The backend exposes a small REST API and stores aliases in `aliases.json` in the project root. Routes are configured in `AliasEndpoints.cs` and operate on an `AliasService` that manages the data file.
+The backend exposes a small REST API and stores aliases in `aliases.json` in the project root. Routes are configured in `AliasEndpointExtensions.cs` and operate on an `AliasService` that manages the data file.
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project provides a minimal ASP.NET Core backend with an Angular frontend to
 
 ## Backend
 
-The backend exposes a small REST API and stores aliases in `aliases.json` in the project root.
+The backend exposes a small REST API and stores aliases in `aliases.json` in the project root. Routes are configured in `AliasEndpoints.cs` and operate on an `AliasService` that manages the data file.
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# url_alias
+# URL Alias Web App
+
+This project provides a minimal ASP.NET Core backend with an Angular frontend to manage URL aliases.
+
+## Backend
+
+The backend exposes a small REST API and stores aliases in `aliases.json` in the project root.
+
+### Run
+
+```bash
+# from the `Backend` directory
+dotnet run
+```
+
+The API will be available at `http://localhost:5000`.
+
+## Frontend
+
+The frontend is a basic Angular application that interacts with the API.
+
+### Run
+
+```bash
+# from the `frontend` directory
+npm install
+npm start  # serves the app on http://localhost:4200
+```
+
+While developing locally, the `proxy.conf.json` routes `/api` calls to the backend.
+

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json.schemastore.org/angular-cli",
+  "version": 1,
+  "projects": {
+    "url-alias-frontend": {
+      "projectType": "application",
+      "root": "src",
+      "sourceRoot": "src",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/url-alias-frontend",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.app.json",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "url-alias-frontend:build"
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "url-alias-frontend"
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "url-alias-frontend",
+  "version": "0.1.0",
+  "scripts": {
+    "start": "ng serve",
+    "build": "ng build"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "^17.0.0",
+    "@angular/common": "^17.0.0",
+    "@angular/compiler": "^17.0.0",
+    "@angular/core": "^17.0.0",
+    "@angular/forms": "^17.0.0",
+    "@angular/platform-browser": "^17.0.0",
+    "@angular/platform-browser-dynamic": "^17.0.0",
+    "rxjs": "^7.5.0",
+    "tslib": "^2.0.0",
+    "zone.js": "^0.14.0"
+  },
+  "devDependencies": {
+    "@angular/cli": "^17.0.0",
+    "@angular/compiler-cli": "^17.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,0 +1,6 @@
+{
+  "/api": {
+    "target": "http://localhost:5000",
+    "secure": false
+  }
+}

--- a/frontend/src/app/alias.service.ts
+++ b/frontend/src/app/alias.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+export interface AliasEntry { alias: string; url: string; }
+
+@Injectable()
+export class AliasService {
+  private base = '/api/aliases';
+  constructor(private http: HttpClient) {}
+
+  list() {
+    return this.http.get<Record<string, string>>(this.base);
+  }
+
+  add(alias: string, url: string) {
+    return this.http.post<AliasEntry>(this.base, { alias, url });
+  }
+
+  get(alias: string) {
+    return this.http.get<string>(`${this.base}/${alias}`);
+  }
+}

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,0 +1,11 @@
+<h1>URL Aliases</h1>
+<form (submit)="add(); $event.preventDefault();">
+  <input [(ngModel)]="alias" name="alias" placeholder="Alias" />
+  <input [(ngModel)]="url" name="url" placeholder="URL" />
+  <button type="submit">Add</button>
+</form>
+<ul>
+  <li *ngFor="let a of (aliases | keyvalue)">
+    {{a.key}}: {{a.value}}
+  </li>
+</ul>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,0 +1,31 @@
+import { Component, OnInit } from '@angular/core';
+import { AliasService } from './alias.service';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html'
+})
+export class AppComponent implements OnInit {
+  alias = '';
+  url = '';
+  aliases: Record<string, string> = {};
+
+  constructor(private service: AliasService) {}
+
+  ngOnInit() {
+    this.refresh();
+  }
+
+  refresh() {
+    this.service.list().subscribe(data => this.aliases = data);
+  }
+
+  add() {
+    if (!this.alias || !this.url) return;
+    this.service.add(this.alias, this.url).subscribe(() => {
+      this.alias = '';
+      this.url = '';
+      this.refresh();
+    });
+  }
+}

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,0 +1,15 @@
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
+
+import { AppComponent } from './app.component';
+import { AliasService } from './alias.service';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule, FormsModule, HttpClientModule],
+  providers: [AliasService],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>URL Alias</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+  <app-root>Loading...</app-root>
+</body>
+</html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,5 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/frontend/src/polyfills.ts
+++ b/frontend/src/polyfills.ts
@@ -1,0 +1,1 @@
+import 'zone.js';

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,1 @@
+body { font-family: Arial, sans-serif; margin: 2em; }

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts",
+    "src/polyfills.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "module": "es2020",
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "target": "es2017",
+    "typeRoots": [
+      "node_modules/@types"
+    ],
+    "lib": [
+      "es2018",
+      "dom"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- replace Python CLI with ASP.NET Core backend
- add Angular frontend for interacting with the API
- document new workflow in README

## Testing
- `dotnet build Backend` *(fails: dotnet not installed)*
- `npm run build` *(fails: ng not installed and network access blocked)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853f9510014833189349939cf7b1b00