### PR TITLE
Use memory cache for alias service

### DIFF
--- a/Backend/AliasEndpointExtensions.cs
+++ b/Backend/AliasEndpointExtensions.cs
@@ -7,15 +7,15 @@ public static class AliasEndpointExtensions
 {
     public static void MapAliasEndpoints(this WebApplication app)
     {
-        app.MapGet("/api/aliases", (AliasService svc) => svc.GetAll());
+        app.MapGet("/api/aliases", (IAliasService svc) => svc.GetAll());
 
-        app.MapGet("/api/aliases/{alias}", (string alias, AliasService svc) =>
+        app.MapGet("/api/aliases/{alias}", (string alias, IAliasService svc) =>
         {
             var url = svc.TryGet(alias);
             return url is not null ? Results.Ok(url) : Results.NotFound();
         });
 
-        app.MapPost("/api/aliases", (AliasEntry input, AliasService svc) =>
+        app.MapPost("/api/aliases", (AliasEntry input, IAliasService svc) =>
         {
             var result = svc.Add(input);
             return result == AddResult.Added

--- a/Backend/AliasService.cs
+++ b/Backend/AliasService.cs
@@ -5,7 +5,14 @@ namespace UrlAlias;
 public record AliasEntry(string Alias, string Url, DateTimeOffset? ExpiresAt = null);
 public enum AddResult { Added, Exists }
 
-public class AliasService
+public interface IAliasService
+{
+    IDictionary<string, string> GetAll();
+    string? TryGet(string alias);
+    AddResult Add(AliasEntry entry);
+}
+
+public class AliasService : IAliasService
 {
     private readonly IMemoryCache _cache;
     private readonly object _lock = new();

--- a/Backend/AliasService.cs
+++ b/Backend/AliasService.cs
@@ -1,24 +1,37 @@
-using System.Text.Json;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace UrlAlias;
 
-public record AliasEntry(string Alias, string Url);
+public record AliasEntry(string Alias, string Url, DateTimeOffset? ExpiresAt = null);
 public enum AddResult { Added, Exists }
 
 public class AliasService
 {
-    private readonly string _dataFile;
+    private readonly IMemoryCache _cache;
     private readonly object _lock = new();
-    public AliasService(string dataFile)
+    private readonly HashSet<string> _keys = new();
+
+    public AliasService(IMemoryCache cache)
     {
-        _dataFile = dataFile;
+        _cache = cache;
     }
 
     public IDictionary<string, string> GetAll()
     {
         lock (_lock)
         {
-            return Load();
+            var result = new Dictionary<string, string>();
+            var remove = new List<string>();
+            foreach (var key in _keys)
+            {
+                if (_cache.TryGetValue<string>(key, out var url))
+                    result[key] = url!;
+                else
+                    remove.Add(key);
+            }
+            foreach (var r in remove)
+                _keys.Remove(r);
+            return result;
         }
     }
 
@@ -26,8 +39,7 @@ public class AliasService
     {
         lock (_lock)
         {
-            var aliases = Load();
-            return aliases.TryGetValue(alias, out var url) ? url : null;
+            return _cache.TryGetValue<string>(alias, out var url) ? url : null;
         }
     }
 
@@ -35,35 +47,24 @@ public class AliasService
     {
         lock (_lock)
         {
-            var aliases = Load();
-            if (aliases.ContainsKey(entry.Alias))
+            if (_cache.TryGetValue<string>(entry.Alias, out _))
                 return AddResult.Exists;
-            aliases[entry.Alias] = entry.Url;
-            Save(aliases);
+
+            var options = new MemoryCacheEntryOptions
+            {
+                AbsoluteExpiration = entry.ExpiresAt ?? DateTimeOffset.UtcNow.AddHours(12)
+            };
+            options.RegisterPostEvictionCallback((key, value, reason, state) =>
+            {
+                lock (_lock)
+                {
+                    _keys.Remove((string)key);
+                }
+            });
+
+            _cache.Set(entry.Alias, entry.Url, options);
+            _keys.Add(entry.Alias);
             return AddResult.Added;
         }
-    }
-
-    private Dictionary<string, string> Load()
-    {
-        if (File.Exists(_dataFile))
-        {
-            try
-            {
-                var json = File.ReadAllText(_dataFile);
-                return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new();
-            }
-            catch
-            {
-                return new Dictionary<string, string>();
-            }
-        }
-        return new Dictionary<string, string>();
-    }
-
-    private void Save(Dictionary<string, string> aliases)
-    {
-        var json = JsonSerializer.Serialize(aliases, new JsonSerializerOptions { WriteIndented = true });
-        File.WriteAllText(_dataFile, json);
     }
 }

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -2,7 +2,7 @@ using UrlAlias;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddSingleton(new AliasService("aliases.json"));
+builder.Services.AddUrlAliasServices();
 
 var app = builder.Build();
 

--- a/Backend/ServiceCollectionExtensions.cs
+++ b/Backend/ServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace UrlAlias;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddUrlAliasServices(this IServiceCollection services)
+    {
+        services.AddMemoryCache();
+        services.AddScoped<AliasService>();
+        return services;
+    }
+}

--- a/Backend/ServiceCollectionExtensions.cs
+++ b/Backend/ServiceCollectionExtensions.cs
@@ -7,7 +7,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddUrlAliasServices(this IServiceCollection services)
     {
         services.AddMemoryCache();
-        services.AddScoped<AliasService>();
+        services.AddScoped<IAliasService, AliasService>();
         return services;
     }
 }


### PR DESCRIPTION
## Summary
- add service registration extension
- implement AliasService using IMemoryCache with default 12-hour expiry and optional per-entry expiration
- register services in Program.cs

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854010da5a88331b2940c02282165d5