### PR TITLE
Add expiration handling for aliases

### DIFF
--- a/UlrAlias.UnitTests/AliasServiceTests.cs
+++ b/UlrAlias.UnitTests/AliasServiceTests.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using UlrAlias.Backend.Models;
 using UlrAlias.Backend.Services;
 using UlrAlias.Backend.Data;
+using System.Linq;
 
 namespace UlrAlias.UnitTests;
 
@@ -35,7 +36,7 @@ public class AliasServiceTests
     {
         var dbContext = CreateInMemoryDbContext();
         var service = new AliasService(dbContext);
-        var entry = new AliasEntry("test", "https://example.com", null);
+        var entry = new AliasEntry { Alias = "test", Url = "https://example.com" };
 
         var result = await service.AddAsync(entry);
 
@@ -47,11 +48,64 @@ public class AliasServiceTests
     {
         var dbContext = CreateInMemoryDbContext();
         var service = new AliasService(dbContext);
-        var entry = new AliasEntry("test", "https://example.com", null);
+        var entry = new AliasEntry { Alias = "test", Url = "https://example.com" };
         await service.AddAsync(entry);
 
-        var result = await service.AddAsync(entry);
+        var result = await service.AddAsync(new AliasEntry { Alias = "test", Url = "https://example.com/other" });
 
         Assert.Equal(AddResult.Exists, result);
+    }
+
+    [Fact]
+    public async Task Add_AllowsReuse_WhenExistingAliasExpired()
+    {
+        var dbContext = CreateInMemoryDbContext();
+        var service = new AliasService(dbContext);
+        await service.AddAsync(new AliasEntry { Alias = "reuse", Url = "https://example.com", ExpiresAt = DateTime.UtcNow.AddMinutes(-1) });
+
+        var result = await service.AddAsync(new AliasEntry { Alias = "reuse", Url = "https://example.com/new" });
+
+        Assert.Equal(AddResult.Added, result);
+    }
+
+    [Fact]
+    public async Task TryGet_ReturnsNull_WhenAliasExpired()
+    {
+        var dbContext = CreateInMemoryDbContext();
+        var service = new AliasService(dbContext);
+        var expired = new AliasEntry { Alias = "expired", Url = "https://example.com", ExpiresAt = DateTime.UtcNow.AddMinutes(-1) };
+        await service.AddAsync(expired);
+
+        var result = await service.TryGetAsync("expired");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FindAsync_ExcludesExpiredAliases()
+    {
+        var dbContext = CreateInMemoryDbContext();
+        var service = new AliasService(dbContext);
+        await service.AddAsync(new AliasEntry { Alias = "active", Url = "https://example.com" });
+        await service.AddAsync(new AliasEntry { Alias = "expired", Url = "https://example.com", ExpiresAt = DateTime.UtcNow.AddMinutes(-1) });
+
+        var results = await service.FindAsync(0, 10);
+
+        var aliasEntries = results.ToList();
+        Assert.Single(aliasEntries);
+        Assert.Equal("active", aliasEntries[0].Alias);
+    }
+
+    [Fact]
+    public async Task CountAsync_ExcludesExpiredAliases()
+    {
+        var dbContext = CreateInMemoryDbContext();
+        var service = new AliasService(dbContext);
+        await service.AddAsync(new AliasEntry { Alias = "active", Url = "https://example.com" });
+        await service.AddAsync(new AliasEntry { Alias = "expired", Url = "https://example.com", ExpiresAt = DateTime.UtcNow.AddMinutes(-1) });
+
+        var count = await service.CountAsync();
+
+        Assert.Equal(1, count);
     }
 }

--- a/UlrAlias.UnitTests/ApLogicTests.cs
+++ b/UlrAlias.UnitTests/ApLogicTests.cs
@@ -5,6 +5,7 @@ using UlrAlias.Backend.DTos;
 using UlrAlias.Backend.endpoints;
 using UlrAlias.Backend.Models;
 using UlrAlias.Backend.Services;
+using UlrAlias.Backend.Dtos.Responses;
 
 namespace UlrAlias.UnitTests;
 
@@ -32,7 +33,7 @@ public class ApLogicTests
         const string alias = "existing";
         var context = new DefaultHttpContext();
         var mockService = new Mock<IAliasService>();
-        var aliasEntry = new AliasEntry(alias, "https://example.com", null);
+        var aliasEntry = new AliasEntry { Alias = alias, Url = "https://example.com" };
         mockService.Setup(s => s.TryGetAsync(alias, It.IsAny<CancellationToken>())).ReturnsAsync(aliasEntry);
 
         var result = await ApLogic.GetAlias(alias, context, mockService.Object, default);
@@ -52,6 +53,6 @@ public class ApLogicTests
 
         var result = await ApLogic.PostAlias(input, context, mockShortener.Object, mockService.Object, default);
 
-        Assert.IsType<Created<AliasEntryDto>>(result);
+        Assert.IsType<Created<AliasCreatedResponse>>(result);
     }
 }

--- a/UlrAlias/Backend/Data/AliasDbContext.cs
+++ b/UlrAlias/Backend/Data/AliasDbContext.cs
@@ -13,9 +13,12 @@ public class AliasDbContext : DbContext
     {
         modelBuilder.Entity<AliasEntry>(entity =>
         {
-            entity.HasKey(e => e.Alias);
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Alias).IsRequired();
             entity.Property(e => e.Url).IsRequired();
             entity.Property(e => e.ExpiresAt);
+            entity.HasIndex(e => new { e.Alias, e.ExpiresAt });
+            entity.HasIndex(e => e.ExpiresAt);
         });
     }
 }

--- a/UlrAlias/Backend/Dtos/AliasEntryDto.cs
+++ b/UlrAlias/Backend/Dtos/AliasEntryDto.cs
@@ -12,10 +12,15 @@ public class AliasEntryDto
     public required string Url { get; init; }
 
     [DefaultValue("2025-12-31T23:59:59Z")] // Fixed future date for Swagger default
-    public DateTimeOffset? ExpiresAt { get; init; }
+    public DateTime? ExpiresAt { get; init; }
 
     public AliasEntry ToDomain()
     {
-        return new AliasEntry(Alias, Url, ExpiresAt);
+        return new AliasEntry
+        {
+            Alias = Alias,
+            Url = Url,
+            ExpiresAt = ExpiresAt
+        };
     }
 }

--- a/UlrAlias/Backend/Models/AliasEntry.cs
+++ b/UlrAlias/Backend/Models/AliasEntry.cs
@@ -1,3 +1,9 @@
 namespace UlrAlias.Backend.Models;
 
-public record AliasEntry(string Alias, string Url, DateTimeOffset? ExpiresAt);
+public class AliasEntry
+{
+    public int Id { get; set; }
+    public string Alias { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
+    public DateTime? ExpiresAt { get; set; }
+}

--- a/UlrAlias/Backend/Services/AliasService.cs
+++ b/UlrAlias/Backend/Services/AliasService.cs
@@ -1,6 +1,7 @@
 using UlrAlias.Backend.Models;
 using Microsoft.EntityFrameworkCore;
 using UlrAlias.Backend.Data;
+using System.Linq;
 
 namespace UlrAlias.Backend.Services;
 
@@ -15,7 +16,12 @@ public class AliasService : IAliasService
 
     public async Task<AddResult> AddAsync(AliasEntry entry, CancellationToken cancellationToken = default)
     {
-        if (await _dbContext.AliasEntries.AnyAsync(e => e.Alias == entry.Alias, cancellationToken))
+        var now = DateTime.UtcNow;
+        var duplicates = await _dbContext.AliasEntries
+            .Where(e => e.Alias == entry.Alias)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+        if (duplicates.Any(e => e.ExpiresAt == null || e.ExpiresAt > now))
             return AddResult.Exists;
 
         await _dbContext.AliasEntries.AddAsync(entry, cancellationToken);
@@ -25,24 +31,28 @@ public class AliasService : IAliasService
 
     public async Task<AliasEntry?> TryGetAsync(string alias, CancellationToken cancellationToken = default)
     {
-        return await _dbContext.AliasEntries.FirstOrDefaultAsync(e => e.Alias == alias, cancellationToken);
+        var now = DateTime.UtcNow;
+        return await _dbContext.AliasEntries
+            .FirstOrDefaultAsync(e => e.Alias == alias && (e.ExpiresAt == null || e.ExpiresAt > now), cancellationToken);
     }
 
     public async Task<IEnumerable<AliasEntry>> FindAsync(int pageIndex, int pageSize, CancellationToken cancellationToken = default)
     {
+        var now = DateTime.UtcNow;
         return await _dbContext.AliasEntries
             .AsNoTracking()
+            .Where(e => e.ExpiresAt == null || e.ExpiresAt > now)
             .OrderByDescending(e => e.Alias)
             .Skip(pageIndex * pageSize)
             .Take(pageSize)
-            .ToListAsync(cancellationToken)
-            .ContinueWith(task => task.Result.AsEnumerable(), cancellationToken);
+            .ToListAsync(cancellationToken);
     }
 
     public async Task<int> CountAsync(CancellationToken cancellationToken = default)
     {
+        var now = DateTime.UtcNow;
         return await _dbContext.AliasEntries
             .AsNoTracking()
-            .CountAsync(cancellationToken);
+            .CountAsync(e => e.ExpiresAt == null || e.ExpiresAt > now, cancellationToken);
     }
 }

--- a/UlrAlias/Migrations/20250818015215_InitialCreate.Designer.cs
+++ b/UlrAlias/Migrations/20250818015215_InitialCreate.Designer.cs
@@ -25,7 +25,7 @@ namespace UlrAlias.Migrations
                     b.Property<string>("Alias")
                         .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset?>("ExpiresAt")
+                    b.Property<DateTime?>("ExpiresAt")
                         .HasColumnType("TEXT");
 
                     b.Property<string>("Url")

--- a/UlrAlias/Migrations/20250818015215_InitialCreate.cs
+++ b/UlrAlias/Migrations/20250818015215_InitialCreate.cs
@@ -17,7 +17,7 @@ namespace UlrAlias.Migrations
                 {
                     Alias = table.Column<string>(type: "TEXT", nullable: false),
                     Url = table.Column<string>(type: "TEXT", nullable: false),
-                    ExpiresAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true)
+                    ExpiresAt = table.Column<DateTime>(type: "TEXT", nullable: true)
                 },
                 constraints: table =>
                 {

--- a/UlrAlias/Migrations/20250818121132_AddAliasIdAndIndexes.Designer.cs
+++ b/UlrAlias/Migrations/20250818121132_AddAliasIdAndIndexes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using UlrAlias.Backend.Data;
 
@@ -10,9 +11,11 @@ using UlrAlias.Backend.Data;
 namespace UlrAlias.Migrations
 {
     [DbContext(typeof(AliasDbContext))]
-    partial class AliasDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250818121132_AddAliasIdAndIndexes")]
+    partial class AddAliasIdAndIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.19");

--- a/UlrAlias/Migrations/20250818121132_AddAliasIdAndIndexes.cs
+++ b/UlrAlias/Migrations/20250818121132_AddAliasIdAndIndexes.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace UlrAlias.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAliasIdAndIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_AliasEntries",
+                table: "AliasEntries");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Id",
+                table: "AliasEntries",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0)
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_AliasEntries",
+                table: "AliasEntries",
+                column: "Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AliasEntries_Alias_ExpiresAt",
+                table: "AliasEntries",
+                columns: new[] { "Alias", "ExpiresAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AliasEntries_ExpiresAt",
+                table: "AliasEntries",
+                column: "ExpiresAt");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_AliasEntries",
+                table: "AliasEntries");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AliasEntries_Alias_ExpiresAt",
+                table: "AliasEntries");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AliasEntries_ExpiresAt",
+                table: "AliasEntries");
+
+            migrationBuilder.DropColumn(
+                name: "Id",
+                table: "AliasEntries");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_AliasEntries",
+                table: "AliasEntries",
+                column: "Alias");
+        }
+    }
+}

--- a/UlrAlias/Program.cs
+++ b/UlrAlias/Program.cs
@@ -103,11 +103,12 @@ async Task SetupDb(WebApplication webApplication)
 
     if (!await dbContext.AliasEntries.AnyAsync())
     {
-        var entries = Enumerable.Range(1, 1000).Select(i => new AliasEntry(
-            $"alias{i}",
-            $"https://google.com/?q={i}",
-            DateTimeOffset.UtcNow.AddDays(2 + i)
-        ));
+        var entries = Enumerable.Range(1, 1000).Select(i => new AliasEntry
+        {
+            Alias = $"alias{i}",
+            Url = $"https://google.com/?q={i}",
+            ExpiresAt = DateTime.UtcNow.AddDays(2 + i)
+        });
         dbContext.AliasEntries.AddRange(entries);
         await dbContext.SaveChangesAsync();
     }


### PR DESCRIPTION
## Summary
- switch alias storage to use integer primary keys and allow expired aliases to be reused
- index alias and expiration fields for efficient lookups
- ignore expired entries across service queries and test reuse behavior

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a313956b8c8331b251583772b8638b