### PR TITLE
fix: correct UlrAlias Dockerfile paths

### DIFF
--- a/UlrAlias.UnitTests/ApLogicTests.cs
+++ b/UlrAlias.UnitTests/ApLogicTests.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Moq;
 using UlrAlias.Backend.DTos;
+using UlrAlias.Backend.Dtos.Responses;
 using UlrAlias.Backend.endpoints;
 using UlrAlias.Backend.Models;
 using UlrAlias.Backend.Services;
@@ -52,6 +53,6 @@ public class ApLogicTests
 
         var result = await ApLogic.PostAlias(input, context, mockShortener.Object, mockService.Object, default);
 
-        Assert.IsType<Created<AliasEntryDto>>(result);
+        Assert.IsType<Created<AliasCreatedResponse>>(result);
     }
 }

--- a/UlrAlias/Dockerfile
+++ b/UlrAlias/Dockerfile
@@ -9,17 +9,17 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
-COPY ["Ulr_Alias/Ulr_Alias.csproj", "Ulr_Alias/"]
-RUN dotnet restore "./Ulr_Alias/Ulr_Alias.csproj"
+COPY ["UlrAlias/UlrAlias.csproj", "UlrAlias/"]
+RUN dotnet restore "./UlrAlias/UlrAlias.csproj"
 COPY . .
-WORKDIR "/src/Ulr_Alias"
-RUN dotnet build "./Ulr_Alias.csproj" -c $BUILD_CONFIGURATION -o /app/build
+WORKDIR "/src/UlrAlias"
+RUN dotnet build "./UlrAlias.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./Ulr_Alias.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "./UlrAlias.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "Ulr_Alias.dll"]
+ENTRYPOINT ["dotnet", "UlrAlias.dll"]


### PR DESCRIPTION
## Summary
- fix project path references in Dockerfile so container can build and run
- adjust PostAlias unit test to expect AliasCreatedResponse returned from API

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a31ce6e9448331a3fa8682dfe24469